### PR TITLE
#162321042 Feat: Set up PATCH request endpoint to update red-flag report

### DIFF
--- a/server/controllers/PostController.js
+++ b/server/controllers/PostController.js
@@ -38,11 +38,23 @@ class PostController {
       videos: [],
     };
 
-    postDb.push(recordData);
+    postDb.concat(recordData);
 
     res.status(201).json({
       status: 201,
       data: [{ id, message: `Created ${type} successfully` }],
+    });
+  }
+
+  static updateLocation(req, res) {
+    const record = postDb.filter(recordObj => recordObj.id === Number(req.params.id));
+    const { latitude, longitude } = req.body;
+    const id = Number(req.params.id);
+
+    Object.assign({}, record[0], { location: `${latitude}, ${longitude}` });
+
+    res.status(200).json({
+      status: 200, data: [{ id, message: 'Updated red-flag record\'s location' }],
     });
   }
 }

--- a/server/controllers/PostController.js
+++ b/server/controllers/PostController.js
@@ -14,9 +14,7 @@ class PostController {
   }
 
   static getARecord(req, res) {
-    const data = postDb.filter(
-      recordObj => Number(req.params.id) === recordObj.id,
-    );
+    const data = postDb.filter(recordObj => Number(req.params.id) === recordObj.id);
     res.status(200).json({ status: 200, data });
   }
 
@@ -52,6 +50,18 @@ class PostController {
     const id = Number(req.params.id);
 
     Object.assign({}, record[0], { location: `${latitude}, ${longitude}` });
+
+    res.status(200).json({
+      status: 200, data: [{ id, message: 'Updated red-flag record\'s location' }],
+    });
+  }
+
+  static updateComment(req, res) {
+    const record = postDb.filter(recordObj => recordObj.id === Number(req.params.id));
+    const { comment } = req.body;
+    const id = Number(req.params.id);
+
+    Object.assign({}, record[0], { comment });
 
     res.status(200).json({
       status: 200, data: [{ id, message: 'Updated red-flag record\'s location' }],

--- a/server/middleware/ValidatePost.js
+++ b/server/middleware/ValidatePost.js
@@ -60,6 +60,39 @@ class ValidatePost {
     }
     return next();
   }
+
+  static validatePatchLocation(req, res, next) {
+    const { latitude, longitude } = req.body;
+    const records = postDb.filter(recordObj => recordObj.id === Number(req.params.id));
+
+    if (Number.isNaN(Number(req.params.id))) {
+      return res.status(406).json({ status: 406, error: 'The id parameter must be a number' });
+    }
+    if (!records.length) {
+      return res.status(404).json({ status: 404, error: 'Sorry, no record with such id exists' });
+    }
+    if (!latitude) {
+      return res
+        .status(406)
+        .json({ status: 406, error: 'Latitude of the incident location must be specified' });
+    }
+    if (!validate.location.test(latitude)) {
+      return res
+        .status(406)
+        .json({ status: 406, error: 'Latitude must be in a valid format' });
+    }
+    if (!longitude) {
+      return res
+        .status(406)
+        .json({ status: 406, error: 'Longitude of the incident location must be specified' });
+    }
+    if (!validate.location.test(longitude)) {
+      return res
+        .status(406)
+        .json({ status: 406, error: 'Longitude must be in a valid format' });
+    }
+    return next();
+  }
 }
 
 export default ValidatePost;

--- a/server/middleware/ValidatePost.js
+++ b/server/middleware/ValidatePost.js
@@ -61,7 +61,7 @@ class ValidatePost {
     return next();
   }
 
-  static validatePatchLocation(req, res, next) {
+  static validateLocation(req, res, next) {
     const { latitude, longitude } = req.body;
     const records = postDb.filter(recordObj => recordObj.id === Number(req.params.id));
 
@@ -91,6 +91,23 @@ class ValidatePost {
         .status(406)
         .json({ status: 406, error: 'Longitude must be in a valid format' });
     }
+    return next();
+  }
+
+  static validateComment(req, res, next) {
+    const { comment } = req.body;
+
+    if (!comment) {
+      return res
+        .status(406)
+        .json({ status: 406, error: 'A comment narrating the incident must be specified' });
+    }
+    if (comment.length < 20) {
+      return res
+        .status(406)
+        .json({ status: 406, error: 'Your comment/narration should be from 20 characters above' });
+    }
+
     return next();
   }
 }

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -4,13 +4,19 @@ import PostController from '../controllers/PostController';
 
 const router = express.Router();
 
+// Handle requests on the /api/v1 endpoint
 router.get('/', (req, res) => {
   res.status(200).json({ message: 'Welcome to iReporter API v1' });
 });
 
+// Handle POST requests
 router.post('/red-flags', ValidatePost.validatePostRequest, PostController.postRecord);
 
+// Handle all GET requests
 router.get('/red-flags', PostController.getRecords);
 router.get('/red-flags/:id', ValidatePost.validateGetRequest, PostController.getARecord);
+
+// Handle all PATCH requests
+router.patch('/red-flags/:id/location', ValidatePost.validatePatchLocation, PostController.updateLocation);
 
 export default router;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -17,6 +17,7 @@ router.get('/red-flags', PostController.getRecords);
 router.get('/red-flags/:id', ValidatePost.validateGetRequest, PostController.getARecord);
 
 // Handle all PATCH requests
-router.patch('/red-flags/:id/location', ValidatePost.validatePatchLocation, PostController.updateLocation);
+router.patch('/red-flags/:id/location', ValidatePost.validateLocation, PostController.updateLocation);
+router.patch('/red-flags/:id/comment', ValidatePost.validateComment, PostController.updateComment);
 
 export default router;

--- a/server/test/posts.spec.js
+++ b/server/test/posts.spec.js
@@ -265,7 +265,7 @@ describe('PATCH red-flag requests', () => {
   it('should update the location of the red flag resource with the given id', (done) => {
     chai
       .request(app)
-      .patch('/api/v1/red-flags/3')
+      .patch('/api/v1/red-flags/3/location')
       .send({ latitude: '6.5922139', longitude: '3.3427375' })
       .end((err, res) => {
         expect(res).to.has.status(200);
@@ -278,18 +278,44 @@ describe('PATCH red-flag requests', () => {
       });
   });
 
+  it('should return an error if the id of the red flag resource is invalid', (done) => {
+    chai
+      .request(app)
+      .patch('/api/v1/red-flags/fghsys/location')
+      .send({ latitude: '6.5922139', longitude: '3.3427375' })
+      .end((err, res) => {
+        expect(res).to.has.status(406);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('status');
+        expect(res.body.status).to.be.equal(406);
+        done(err);
+      });
+  });
+
+  it('should return an error if the request body is empty', (done) => {
+    chai
+      .request(app)
+      .patch('/api/v1/red-flags/3/location')
+      .send({})
+      .end((err, res) => {
+        expect(res).to.has.status(406);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('status');
+        expect(res.body.status).to.be.equal(406);
+        done(err);
+      });
+  });
+
   it('should return an error if the longitude of the red flag resource is empty', (done) => {
     chai
       .request(app)
-      .patch('/api/v1/red-flags/3')
+      .patch('/api/v1/red-flags/3/location')
       .send({ latitude: '6.5922139', longitude: '' })
       .end((err, res) => {
         expect(res).to.has.status(406);
         expect(res.body).to.be.an('object');
         expect(res.body).to.have.property('status');
-        expect(res.body).to.have.property('data');
-        expect(res.body.data).to.be.an('array');
-        expect(res.body.data[0].id).to.be.equal(3);
+        expect(res.body.status).to.be.equal(406);
         done(err);
       });
   });
@@ -297,15 +323,13 @@ describe('PATCH red-flag requests', () => {
   it('should return an error if the longitude of the red flag resource is invalid', (done) => {
     chai
       .request(app)
-      .patch('/api/v1/red-flags/3')
+      .patch('/api/v1/red-flags/3/location')
       .send({ latitude: '6.5922139', longitude: 'gt6wgw' })
       .end((err, res) => {
         expect(res).to.has.status(406);
         expect(res.body).to.be.an('object');
         expect(res.body).to.have.property('status');
-        expect(res.body).to.have.property('data');
-        expect(res.body.data).to.be.an('array');
-        expect(res.body.data[0].id).to.be.equal(3);
+        expect(res.body.status).to.be.equal(406);
         done(err);
       });
   });
@@ -313,7 +337,7 @@ describe('PATCH red-flag requests', () => {
   it('should return an error if the latitude of the red flag resource is empty', (done) => {
     chai
       .request(app)
-      .patch('/api/v1/red-flags/3')
+      .patch('/api/v1/red-flags/3/location')
       .send({ latitude: '', longitude: '3.3427375' })
       .end((err, res) => {
         expect(res).to.have.status(406);
@@ -328,7 +352,7 @@ describe('PATCH red-flag requests', () => {
   it('should return an error if the latitude of the red flag resource is invalid', (done) => {
     chai
       .request(app)
-      .patch('/api/v1/red-flags/3')
+      .patch('/api/v1/red-flags/3/location')
       .send({ latitide: 'gushs', longitude: '3.3427375' })
       .end((err, res) => {
         expect(res).to.have.status(406);
@@ -360,21 +384,6 @@ describe('PATCH red-flag requests', () => {
     chai
       .request(app)
       .patch('/api/v1/red-flags/3/comment')
-      .send({ comment: '' })
-      .end((err, res) => {
-        expect(res).to.have.status(406);
-        expect(res.body).to.be.an('object');
-        expect(res.body).to.have.property('error');
-        expect(res.body).to.have.property('status');
-        expect(res.body.status).to.equal(406);
-        done(err);
-      });
-  });
-
-  it('should return an error if the red flag id is invalid', (done) => {
-    chai
-      .request(app)
-      .patch('/api/v1/red-flags/ty')
       .send({ comment: '' })
       .end((err, res) => {
         expect(res).to.have.status(406);

--- a/server/test/posts.spec.js
+++ b/server/test/posts.spec.js
@@ -278,7 +278,7 @@ describe('PATCH red-flag requests', () => {
       });
   });
 
-  it('should return an error if the id of the red flag resource is invalid', (done) => {
+  it('should return an error if the id format of the red flag resource is invalid', (done) => {
     chai
       .request(app)
       .patch('/api/v1/red-flags/fghsys/location')
@@ -288,6 +288,20 @@ describe('PATCH red-flag requests', () => {
         expect(res.body).to.be.an('object');
         expect(res.body).to.have.property('status');
         expect(res.body.status).to.be.equal(406);
+        done(err);
+      });
+  });
+
+  it('should return an error if the id of the red flag resource does not exist', (done) => {
+    chai
+      .request(app)
+      .patch('/api/v1/red-flags/10/location')
+      .send({ latitude: '6.5922139', longitude: '3.3427375' })
+      .end((err, res) => {
+        expect(res).to.has.status(404);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('status');
+        expect(res.body.status).to.be.equal(404);
         done(err);
       });
   });
@@ -367,7 +381,7 @@ describe('PATCH red-flag requests', () => {
   it('should update the comment of the red flag resource with the given id', (done) => {
     chai
       .request(app)
-      .patch('/api/v1/red-flags/3/location')
+      .patch('/api/v1/red-flags/3/comment')
       .send({ comment: 'Bribery and extortion by the NPF' })
       .end((err, res) => {
         expect(res).to.has.status(200);
@@ -394,6 +408,26 @@ describe('PATCH red-flag requests', () => {
         done(err);
       });
   });
+
+  it('should return an error if comment is less than 20 characters', (done) => {
+    chai
+      .request(app)
+      .post('/api/v1/red-flags')
+      .send({
+        type: 'red-flag',
+        latitude: '6.5951139',
+        longitude: '3.3429975',
+        comment: 'A short comment',
+      })
+      .end((err, res) => {
+        expect(res).to.have.status(406);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('error');
+        expect(res.body).to.have.property('status');
+        expect(res.body.status).to.equal(406);
+        done(err);
+      });
+  });
 });
 
 describe('DELETE red-flags request', () => {
@@ -402,12 +436,25 @@ describe('DELETE red-flags request', () => {
       .request(app)
       .delete('/api/v1/red-flags/3')
       .end((err, res) => {
-        expect(res).to.have.status(204);
+        expect(res).to.have.status(200);
         expect(res.body).to.be.an('object');
         expect(res.body).to.have.property('status');
         expect(res.body).to.have.property('data');
         expect(res.body.data).to.be.an('array');
         expect(res.body.data[0].id).to.be.equal(3);
+        done(err);
+      });
+  });
+
+  it('should return an error if the id of the red flag resource does not exist', (done) => {
+    chai
+      .request(app)
+      .delete('/api/v1/red-flags/10')
+      .end((err, res) => {
+        expect(res).to.has.status(404);
+        expect(res.body).to.be.an('object');
+        expect(res.body).to.have.property('status');
+        expect(res.body.status).to.be.equal(404);
         done(err);
       });
   });


### PR DESCRIPTION
__What does this PR do?__
This PR sets up the PATCH /api/v1/red-flags/:id/location and PATCH /api/v1/red-flags/:id/comment  endpoints

__Description of tasks__
- Ensure that all the tests for the endpoints are passing
- Request made with the proper details to /api/v1/red-flags/:id/location should update location
- Request made with the proper details to /api/v1/red-flags/:id/comment should update comment

__How can this PR be tested__
- Using Postman, set the request method to PATCH
- Specify the endpoint /api/v1/red-flags/:id/location to test for location update
- Specify the endpoint /api/v1/red-flags/:id/comment to test for comment update

__Link to relevant story__
[#162321042](https://www.pivotaltracker.com/story/show/162321042)