### PR TITLE
 #163472830 Implement change report status

### DIFF
--- a/UI/assets/css/styles.css
+++ b/UI/assets/css/styles.css
@@ -585,7 +585,6 @@ p.stat-value {
   transform: translateX(50%);
   position: fixed;
   color: #fffffa;
-  text-align: center;
   width: 25%;
   margin: 0 auto;
   padding: 20px;
@@ -607,6 +606,10 @@ p.stat-value {
 .toast-hide {
   float: right;
   cursor: pointer;
+  font-size: 2.5em;
+  position: absolute;
+  right: 15px;
+  top: 2px;
 }
 
 /* Reports Table */

--- a/UI/assets/js/admin.js
+++ b/UI/assets/js/admin.js
@@ -37,8 +37,6 @@ function renderReportTable(reportObj, serial) {
   const form = document.createElement('form');
   const selectStatus = document.createElement('select');
   selectStatus.classList.add('form-element');
-  selectStatus.setAttribute('name', 'status');
-  selectStatus.setAttribute('id', id);
   const statusOptions = ['drafted', 'investigating', 'resolved', 'rejected'];
   statusOptions.map((statusOption) => {
     const option = document.createElement('option');
@@ -52,6 +50,8 @@ function renderReportTable(reportObj, serial) {
   const submitBtn = document.createElement('button');
   submitBtn.setAttribute('type', 'submit');
   submitBtn.classList.add('btn', 'btn-primary', 'update-record');
+  submitBtn.setAttribute('data-id', id);
+  submitBtn.setAttribute('data-type', type);
   submitBtn.textContent = 'Submit';
   form.append(selectStatus);
   form.append(submitBtn);
@@ -60,7 +60,7 @@ function renderReportTable(reportObj, serial) {
   document.querySelector('tbody').append(row);
 }
 
-function getReports(endpoint = null) {
+function getAllReports(endpoint = null) {
   const url = `http://localhost:3000/api/v1/${endpoint}`;
   const token = window.localStorage.getItem('token');
 
@@ -81,9 +81,45 @@ function getReports(endpoint = null) {
     .catch(error => console.log(error));
 }
 
+function updateReportStatus(endpoint, id, status) {
+  const url = `http://localhost:3000/api/v1/${endpoint}s/${id}/status`;
+  const token = window.localStorage.getItem('token');
+
+  fetch(url, {
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ status }),
+  })
+    .then(response => response.json())
+    .then((responseObj) => {
+      console.log(responseObj);
+      if (responseObj.status === 200) {
+        console.log('Report updated');
+      }
+    })
+    .catch(error => console.log(error));
+}
+
+document.body.addEventListener('click', (evt) => {
+  evt.preventDefault();
+  const { target } = evt;
+  const classNames = Array.from(target.classList);
+  if (classNames.includes('update-record')) {
+    const status = target.previousElementSibling.value;
+    console.log(status);
+    const id = target.getAttribute('data-id');
+    const type = target.getAttribute('data-type');
+    updateReportStatus(type, id, status);
+    console.log({ type, id, status });
+  }
+});
+
 const role = localStorage.getItem('role');
 if (role !== 'admin') {
   window.location.href = './index.html';
 } else {
-  getReports('red-flags');
+  getAllReports('red-flags');
 }

--- a/UI/assets/js/admin.js
+++ b/UI/assets/js/admin.js
@@ -95,9 +95,12 @@ function updateReportStatus(endpoint, id, status) {
   })
     .then(response => response.json())
     .then((responseObj) => {
-      console.log(responseObj);
       if (responseObj.status === 200) {
-        console.log('Report updated');
+        const toast = document.querySelector('.toast');
+        toast.classList.toggle('toast-show');
+        setTimeout(() => {
+          toast.classList.remove('toast-show');
+        }, 3000);
       }
     })
     .catch(error => console.log(error));
@@ -109,11 +112,9 @@ document.body.addEventListener('click', (evt) => {
   const classNames = Array.from(target.classList);
   if (classNames.includes('update-record')) {
     const status = target.previousElementSibling.value;
-    console.log(status);
     const id = target.getAttribute('data-id');
     const type = target.getAttribute('data-type');
     updateReportStatus(type, id, status);
-    console.log({ type, id, status });
   }
 });
 

--- a/UI/assets/js/authenticateUser.js
+++ b/UI/assets/js/authenticateUser.js
@@ -14,11 +14,11 @@ function authenticateUser(userObj, endpoint) {
         localStorage.setItem('token', token);
 
         if (user.isadmin === 'true') {
-          localStorage.setItem('role', 'user');
+          localStorage.setItem('role', 'admin');
           window.location.href = './admin.html';
         } else {
-          localStorage.setItem('role', 'admin');
-          window.location.href = './profile.html';
+          localStorage.setItem('role', 'user');
+          window.location.href = './dashboard.html';
         }
       }
     })

--- a/UI/assets/js/getReports.js
+++ b/UI/assets/js/getReports.js
@@ -66,7 +66,7 @@ function renderReportCard(reportObj) {
   cardDiv.append(reportMedia);
   cardDiv.append(reportLocation);
 
-  if (window.location.href.includes('dashboard')) {
+  if (window.location.href.includes('dashboard') && status === 'drafted') {
     const editBtn = document.createElement('a');
     const deleteBtn = document.createElement('button');
     const editIcon = document.createElement('i');

--- a/server/middleware/AuthenticateUser.js
+++ b/server/middleware/AuthenticateUser.js
@@ -67,7 +67,6 @@ class AuthenticateUser {
     const { isadmin } = payload;
 
     if (isadmin === 'false') {
-      console.log('You are not an admin');
       return res.status(401).json({
         status: 401,
         error: 'You are not authorized to access this endpoint.',

--- a/server/middleware/ValidateIncident.js
+++ b/server/middleware/ValidateIncident.js
@@ -127,10 +127,11 @@ class ValidateIncident {
       const query = 'SELECT status FROM incidents WHERE id = $1';
 
       return pool.query(query, [id], (err, dbRes) => {
-        console.log(dbRes.rows[0].status);
         if (dbRes.rows[0].status !== 'drafted') {
-          return res.status(409).json({ status: 409, error: 'You cannot modify this request after its status has been updated' });
+          return res.status(409).json({ status: 409, error: 'You cannot modify this report after its status has been updated' });
         }
+
+        return next();
       });
     }
 

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -56,6 +56,7 @@ router.patch(
   AuthenticateUser.verifyUser,
   ValidateIncident.validateIncidentId,
   ValidateIncident.validateCoordinates,
+  ValidateIncident.validateStatus,
   IncidentController.updateIncident,
 );
 router.patch(
@@ -64,6 +65,7 @@ router.patch(
   AuthenticateUser.verifyUser,
   ValidateIncident.validateIncidentId,
   ValidateIncident.validateComment,
+  ValidateIncident.validateStatus,
   IncidentController.updateIncident,
 );
 router.patch(
@@ -71,6 +73,7 @@ router.patch(
   ValidateIncident.validateIncidentType,
   AuthenticateUser.verifyAdmin,
   ValidateIncident.validateIncidentId,
+  ValidateIncident.validateStatus,
   IncidentController.updateIncident,
 );
 

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -83,6 +83,7 @@ router.delete(
   ValidateIncident.validateIncidentType,
   AuthenticateUser.verifyUser,
   ValidateIncident.validateIncidentId,
+  ValidateIncident.validateStatus,
   IncidentController.deleteIncident,
 );
 

--- a/server/test/incidents.spec.js
+++ b/server/test/incidents.spec.js
@@ -520,6 +520,36 @@ describe('PATCH red-flag requests', () => {
       });
   });
 
+  it('should return an error if incorrect status was specified', (done) => {
+    chai
+      .request(app)
+      .patch('/api/v1/red-flags/1/status')
+      .set('authorization', `Bearer ${adminToken}`)
+      .send({ status: 'rejected%^&' })
+      .end((err, res) => {
+        expect(res).to.has.status(400);
+        expect(res.body.status).to.be.equal(400);
+        expect(res.body).to.have.property('status');
+        expect(res.body.error).to.be.equal('You need to specify a correct status type');
+        done(err);
+      });
+  });
+
+  it('should return an error if report is trying to be edited after is has been updated', (done) => {
+    chai
+      .request(app)
+      .patch('/api/v1/red-flags/1/comment')
+      .set('authorization', `Bearer ${userToken}`)
+      .send({ comment: 'Modifying the existing comment with a longer comment' })
+      .end((err, res) => {
+        expect(res).to.has.status(409);
+        expect(res.body.status).to.be.equal(409);
+        expect(res.body).to.have.property('status');
+        expect(res.body.error).to.be.equal('You cannot modify this report after its status has been updated');
+        done(err);
+      });
+  });
+
   it('should return an error if the comment of the red flag resource is empty', (done) => {
     chai
       .request(app)
@@ -581,7 +611,7 @@ describe('DELETE red-flags request', () => {
       });
   });
 
-  it('should return an error if the token cannot tbe authenticated', (done) => {
+  it('should return an error if the token cannot the authenticated', (done) => {
     chai
       .request(app)
       .delete('/api/v1/red-flags/1/')


### PR DESCRIPTION
__What does this PR do?__
This PR implements the change status feature which enables an authenticated admin to change the status of any report created on the platform and also ensures that users can not update their reports after the status has been changed.

__Description of tasks__
- Ensure only users with admin role can change report status
- Ensure that users cannot edit or delete a report after that report's status has been updated
- Ensure that a toast message is displayed, notifying the admin if the update was successful or not

__How to test this PR__
- Visit https://chrismarcel.github.io/iReporter/UI/login.html
- Log in as an admin using the parameters email: admindemo@email.com password: 12345678
- You should be redirected to the Admin dashboard page, displaying all the reports
- Update the status of any of the reports
- Reloading the page, you should see the status of that report has been updated

__Link to relevant stories__
[#163472830](https://www.pivotaltracker.com/story/show/163472830)